### PR TITLE
Always remove original tag for Thymeleaf 2 tag replacement procesor

### DIFF
--- a/broadleaf-thymeleaf2-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf2/dialect/DelegatingThymeleaf2TagReplacementProcessor.java
+++ b/broadleaf-thymeleaf2-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf2/dialect/DelegatingThymeleaf2TagReplacementProcessor.java
@@ -69,8 +69,8 @@ public class DelegatingThymeleaf2TagReplacementProcessor extends AbstractElement
                 }
                 lastNode = currentNode;
             }
-            element.getParent().removeChild(element);
         }
+        element.getParent().removeChild(element);
         return ProcessorResult.OK;
     }
 


### PR DESCRIPTION
Moved the code that removes the original tag so that it always removed the original tag regardless if getReplacementModel returned a null model or not