### PR TITLE
Moved declaration of the SimpleCacheKeyResolver to Java config

### DIFF
--- a/broadleaf-thymeleaf2-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf2/site/config/Thymeleaf2SiteConfig.java
+++ b/broadleaf-thymeleaf2-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf2/site/config/Thymeleaf2SiteConfig.java
@@ -17,6 +17,8 @@
  */
 package org.broadleafcommerce.presentation.thymeleaf2.site.config;
 
+import org.broadleafcommerce.presentation.cache.service.SimpleCacheKeyResolver;
+import org.broadleafcommerce.presentation.cache.service.TemplateCacheKeyResolverService;
 import org.broadleafcommerce.presentation.dialect.BroadleafProcessor;
 import org.broadleafcommerce.presentation.resolver.BroadleafTemplateResolver;
 import org.broadleafcommerce.presentation.thymeleaf2.config.Thymeleaf2ConfigUtils;
@@ -64,6 +66,11 @@ public class Thymeleaf2SiteConfig {
     @Bean
     public IProcessor blArbitraryHtmlInjectionProcessor() {
         return new ArbitraryHtmlInsertionProcessor();
+    }
+    
+    @Bean
+    public TemplateCacheKeyResolverService blTemplateCacheKeyResolver() {
+        return new SimpleCacheKeyResolver();
     }
     
     @Bean

--- a/broadleaf-thymeleaf2-presentation/src/main/resources/blc-config/bl-thymeleaf2-presentation-base-applicationContext.xml
+++ b/broadleaf-thymeleaf2-presentation/src/main/resources/blc-config/bl-thymeleaf2-presentation-base-applicationContext.xml
@@ -49,7 +49,6 @@
 
     <bean id="thymeleafSpringStandardDialect" class="org.thymeleaf.spring4.dialect.SpringStandardDialect" />
     <bean id="blVariableExpressionEvaluator" class="org.broadleafcommerce.presentation.thymeleaf2.expression.BroadleafVariableExpressionEvaluator" />
-    <bean id="blTemplateCacheKeyResolver" class="org.broadleafcommerce.presentation.cache.service.SimpleCacheKeyResolver" />
     
     <bean id="blEmailClasspathTemplateResolver" class="org.broadleafcommerce.presentation.resolver.BroadleafClasspathTemplateResolver">
         <property name="prefix" value="emailTemplates/" />

--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/site/config/Thymeleaf3SiteConfig.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/site/config/Thymeleaf3SiteConfig.java
@@ -17,6 +17,8 @@
  */
 package org.broadleafcommerce.presentation.thymeleaf3.site.config;
 
+import org.broadleafcommerce.presentation.cache.service.SimpleCacheKeyResolver;
+import org.broadleafcommerce.presentation.cache.service.TemplateCacheKeyResolverService;
 import org.broadleafcommerce.presentation.dialect.BroadleafProcessor;
 import org.broadleafcommerce.presentation.resolver.BroadleafTemplateResolver;
 import org.broadleafcommerce.presentation.thymeleaf3.config.Thymeleaf3ConfigUtils;
@@ -64,6 +66,11 @@ public class Thymeleaf3SiteConfig {
     @Bean
     public IProcessor blArbitraryHtmlInjectionProcessor() {
         return new ArbitraryHtmlInsertionProcessor();
+    }
+    
+    @Bean
+    public TemplateCacheKeyResolverService blTemplateCacheKeyResolver() {
+        return new SimpleCacheKeyResolver();
     }
     
     @Bean

--- a/broadleaf-thymeleaf3-presentation/src/main/resources/blc-config/bl-thymeleaf3-presentation-base-applicationContext.xml
+++ b/broadleaf-thymeleaf3-presentation/src/main/resources/blc-config/bl-thymeleaf3-presentation-base-applicationContext.xml
@@ -50,7 +50,6 @@
     
     <bean id="thymeleafSpringStandardDialect" class="org.thymeleaf.spring4.dialect.SpringStandardDialect" />
     <bean id="blVariableExpressionObjectFactory" class="org.broadleafcommerce.presentation.thymeleaf3.expression.BroadleafVariableExpressionObjectFactory" />
-    <bean id="blTemplateCacheKeyResolver" class="org.broadleafcommerce.presentation.cache.service.SimpleCacheKeyResolver" />
     
     <bean id="blEmailClasspathTemplateResolver" class="org.broadleafcommerce.presentation.resolver.BroadleafClasspathTemplateResolver">
         <property name="prefix" value="emailTemplates/" />


### PR DESCRIPTION
Because of the ordering of merged xml files, the SimpleCacheKeyResolver was being used for the bean `blTemplateCacheKeyResolver` instead of the EnterpriseCacheKeyResolver when Enterprise is included since PresentationLayer gets loaded later than Enterprise. By moving this to Java config it ensures that XML overrides work as intended for `blTemplateCacheKeyResolver.