### PR TITLE
Updated the BLC version to 6.1.5-GA so that this module does not indirectly forces Hibernate version back to 5.3.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.uri>${project.baseUri}</project.uri>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>6.1.0-GA</blc.version>
+        <blc.version>6.1.5-GA</blc.version>
         <broadleaf-common-presentation.version>1.1.1-GA</broadleaf-common-presentation.version>
     </properties>
 


### PR DESCRIPTION
Fixes https://github.com/BroadleafCommerce/QA/issues/4332
