### PR TITLE
Added in applicationContext in the properties of the message body so the context could be used and allowed expressions to be used when in the EngineContext (for emails).

### DIFF
--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/email/BroadleafThymeleaf3MessageCreator.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/email/BroadleafThymeleaf3MessageCreator.java
@@ -20,32 +20,47 @@ package org.broadleafcommerce.presentation.thymeleaf3.email;
 import org.broadleafcommerce.common.email.service.info.EmailInfo;
 import org.broadleafcommerce.common.email.service.message.MessageCreator;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.expression.ThymeleafEvaluationContext;
 
 import java.util.Iterator;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+
 public class BroadleafThymeleaf3MessageCreator extends MessageCreator {
 
     private TemplateEngine templateEngine;
+    
+    private ApplicationContext applicationContext;
     
     public BroadleafThymeleaf3MessageCreator(TemplateEngine templateEngine, JavaMailSender mailSender) {
         super(mailSender);
         this.templateEngine = templateEngine;        
     }
 
+    public void setApplicationContext(@Nonnull final ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+    
     @Override
     public String buildMessageBody(EmailInfo info, Map<String,Object> props) {
         BroadleafRequestContext blcContext = BroadleafRequestContext.getBroadleafRequestContext();
-
+      
         final Context thymeleafContext = new Context();
         if (blcContext != null && blcContext.getJavaLocale() != null) {
             thymeleafContext.setLocale(blcContext.getJavaLocale());
         }
 
         if (props != null) {
+            if (props.get(ThymeleafEvaluationContext.THYMELEAF_EVALUATION_CONTEXT_CONTEXT_VARIABLE_NAME) == null) {
+                props.put(ThymeleafEvaluationContext.THYMELEAF_EVALUATION_CONTEXT_CONTEXT_VARIABLE_NAME,
+                        new ThymeleafEvaluationContext(applicationContext, null));
+            }
             Iterator<String> propsIterator = props.keySet().iterator();
             while(propsIterator.hasNext()) {
                 String key = propsIterator.next();

--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/expression/BroadleafVariableExpressionObjectFactory.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/expression/BroadleafVariableExpressionObjectFactory.java
@@ -18,6 +18,7 @@
 package org.broadleafcommerce.presentation.thymeleaf3.expression;
 
 import org.broadleafcommerce.common.web.expression.BroadleafVariableExpression;
+import org.thymeleaf.context.IEngineContext;
 import org.thymeleaf.context.IExpressionContext;
 import org.thymeleaf.context.IWebContext;
 import org.thymeleaf.expression.IExpressionObjectFactory;
@@ -45,7 +46,7 @@ public class BroadleafVariableExpressionObjectFactory implements IExpressionObje
 
     @Override
     public Object buildObject(IExpressionContext context, String expressionObjectName) {
-        if (context instanceof IWebContext) {
+        if (context instanceof IWebContext || context instanceof IEngineContext) {
             for (BroadleafVariableExpression expression : expressions) {
                 if (expressionObjectName.equals(expression.getName())) {
                     return expression;


### PR DESCRIPTION
  Fixes https://github.com/BroadleafCommerce/QA/issues/4452
