### PR TITLE
Fix to allow partial template file changes that are already cached to be invalidated and removed from cache

### DIFF
--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/extension/ThymeleafTemplateCacheExtensionHandler.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/extension/ThymeleafTemplateCacheExtensionHandler.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * broadleaf-thymeleaf3-presentation
+ * %%
+ * Copyright (C) 2009 - 2021 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.presentation.thymeleaf3.extension;
+
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.common.extension.TemplateCacheExtensionHandler;
+import org.broadleafcommerce.common.extension.TemplateCacheExtensionManager;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.cache.TemplateCacheKey;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+@Service("blThymeleafTemplateCacheExtensionHandler")
+public class ThymeleafTemplateCacheExtensionHandler implements TemplateCacheExtensionHandler {
+
+    @Resource(name = "blTemplateCacheExtensionManager")
+    protected TemplateCacheExtensionManager extensionManager;
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @PostConstruct
+    public void init(){
+        if (isEnabled()) {
+            extensionManager.registerHandler(this);
+        }
+    }
+
+    @Override
+    public ExtensionResultStatusType getTemplateCacheKey(Object key, String template, ExtensionResultHolder<Object> extensionResultHolder) {
+        if(key instanceof TemplateCacheKey) {
+            TemplateCacheKey templateCacheKey = ((TemplateCacheKey) key);
+            extensionResultHolder.setResult(new TemplateCacheKey(templateCacheKey.getOwnerTemplate(), template, templateCacheKey.getTemplateSelectors(), templateCacheKey.getLineOffset(), templateCacheKey.getColOffset(), templateCacheKey.getTemplateMode(), templateCacheKey.getTemplateResolutionAttributes()));
+            return ExtensionResultStatusType.HANDLED;
+        }
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
+
+    @Override
+    public ExtensionResultStatusType getTemplateName(Object key, ExtensionResultHolder<Object> extensionResultHolder) {
+        if(key instanceof TemplateCacheKey) {
+            TemplateCacheKey templateCacheKey = ((TemplateCacheKey) key);
+            String template = templateCacheKey.getTemplate();
+            extensionResultHolder.setResult(template);
+            return ExtensionResultStatusType.HANDLED;
+        }
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
+}

--- a/broadleaf-thymeleaf3-presentation/src/main/resources/blc-config/site/bl-thymeleaf3-presentation-applicationContext.xml
+++ b/broadleaf-thymeleaf3-presentation/src/main/resources/blc-config/site/bl-thymeleaf3-presentation-applicationContext.xml
@@ -30,5 +30,6 @@
     
     <import resource="classpath:blc-config/bl-thymeleaf3-presentation-base-applicationContext.xml" />
     <context:component-scan base-package="org.broadleafcommerce.presentation.thymeleaf3.site.config" />
-    
+    <context:component-scan base-package="org.broadleafcommerce.presentation.thymeleaf3.extension" />
+
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>broadleaf-module-parent</artifactId>
-        <version>2.0.13-GA</version>
+        <version>3.0.5-GA</version>
     </parent>
 
     <groupId>org.broadleafcommerce</groupId>
@@ -20,7 +20,7 @@
     <properties>
         <project.uri>${project.baseUri}</project.uri>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>5.2.1-GA</blc.version>
+        <blc.version>5.2.22-SNAPSHOT</blc.version>
         <broadleaf-common-presentation.version>1.0.2-GA</broadleaf-common-presentation.version>
     </properties>
 


### PR DESCRIPTION
Fix for partials templates cache invalidation 5.2 v

A Brief Overview
Changed cache key

Link to QA issue
BroadleafCommerce/QA#4501

Add Milestone to the right panel and delete this section (required):
1.1.5-GA

Additional context
https://secure.helpscout.net/conversation/1580375642/47107?folderId=4202960