### PR TITLE
Fixes the issue where was showing a lot of same lines in the logs

### DIFF
--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafThymeleaf3DatabaseResourceResolver.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafThymeleaf3DatabaseResourceResolver.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.presentation.thymeleaf3.resolver;
 import org.apache.commons.io.FilenameUtils;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.common.web.resource.BroadleafContextUtil;
 import org.broadleafcommerce.core.web.resolver.DatabaseResourceResolverExtensionHandler;
 import org.broadleafcommerce.core.web.resolver.DatabaseResourceResolverExtensionManager;
@@ -33,7 +34,7 @@ import java.io.Reader;
 
 
 /**
- * An implementation of {@link IResourceResolver} that provides an extension point for retrieving
+ * An implementation of {@link ITemplateResource} that provides an extension point for retrieving
  * templates from the database.
  * 
  * @author Andre Azzolini (apazzolini)
@@ -90,15 +91,15 @@ public class BroadleafThymeleaf3DatabaseResourceResolver implements ITemplateRes
     protected InputStream resolveResource() {
         try {
             blcContextUtil.establishThinRequestContext();
-
-            ExtensionResultHolder erh = new ExtensionResultHolder();
+            ExtensionResultHolder<InputStream> erh = new ExtensionResultHolder<>();
             ExtensionResultStatusType result = extensionManager.getProxy().resolveResource(erh, path);
             if (result == ExtensionResultStatusType.HANDLED) {
                 return (InputStream) erh.getContextMap().get(DatabaseResourceResolverExtensionHandler.IS_KEY);
             }
             return null;
         } finally {
-            blcContextUtil.clearThinRequestContext();
+            BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
+            brc.setTheme(null);
         }
     }
 

--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafThymeleaf3DatabaseResourceResolver.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafThymeleaf3DatabaseResourceResolver.java
@@ -90,8 +90,9 @@ public class BroadleafThymeleaf3DatabaseResourceResolver implements ITemplateRes
     
     protected InputStream resolveResource() {
         try {
-            blcContextUtil.establishThinRequestContext();
-            ExtensionResultHolder<InputStream> erh = new ExtensionResultHolder<>();
+            this.blcContextUtil.establishThinRequestContext();
+
+            ExtensionResultHolder erh = new ExtensionResultHolder();
             ExtensionResultStatusType result = extensionManager.getProxy().resolveResource(erh, path);
             if (result == ExtensionResultStatusType.HANDLED) {
                 return (InputStream) erh.getContextMap().get(DatabaseResourceResolverExtensionHandler.IS_KEY);


### PR DESCRIPTION
**A Brief Overview**
In BroadleafThymeleaf3DatabaseResourceResolver.resolveResource() changed finally block: clean only Theme from BroadleafRequestContext

**Link to QA issue**
[QA-4797](https://github.com/BroadleafCommerce/QA/issues/4797)