### PR TITLE
Cache if template exists for the path for ClassLoaderTemplateResolver

### DIFF
--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/config/Thymeleaf3ConfigUtils.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/config/Thymeleaf3ConfigUtils.java
@@ -34,9 +34,11 @@ import org.broadleafcommerce.presentation.thymeleaf3.dialect.DelegatingThymeleaf
 import org.broadleafcommerce.presentation.thymeleaf3.dialect.DelegatingThymeleaf3ModelModifierProcessor;
 import org.broadleafcommerce.presentation.thymeleaf3.dialect.DelegatingThymeleaf3TagReplacementProcessor;
 import org.broadleafcommerce.presentation.thymeleaf3.dialect.DelegatingThymeleaf3TagTextModifierProcessor;
+import org.broadleafcommerce.presentation.thymeleaf3.resolver.BroadleafClassLoaderTemplateResolver;
 import org.broadleafcommerce.presentation.thymeleaf3.resolver.BroadleafThymeleaf3DatabaseTemplateResolver;
 import org.broadleafcommerce.presentation.thymeleaf3.resolver.BroadleafThymeleaf3StringTemplateResolver;
 import org.broadleafcommerce.presentation.thymeleaf3.resolver.DelegatingThymeleaf3TemplateResolver;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.processor.IProcessor;
@@ -57,6 +59,9 @@ public class Thymeleaf3ConfigUtils {
     
     @Resource
     protected ApplicationContext applicationContext;
+
+    @Value("${cache.template.exists.for.path:true}")
+    protected boolean cacheIsTemplateExist;
             
     public Set<IProcessor> getDialectProcessors(Collection<BroadleafProcessor> blcProcessors) {
         Set<IProcessor> iProcessors = new HashSet<>();
@@ -138,7 +143,12 @@ public class Thymeleaf3ConfigUtils {
     }
     
     protected ClassLoaderTemplateResolver createClassLoaderTemplateResolver(BroadleafTemplateResolver resolver) {
-        ClassLoaderTemplateResolver classpathResolver = new ClassLoaderTemplateResolver();
+        ClassLoaderTemplateResolver classpathResolver = null;
+        if (cacheIsTemplateExist) {
+            classpathResolver = new BroadleafClassLoaderTemplateResolver();
+        } else {
+            classpathResolver = new ClassLoaderTemplateResolver();
+        }
         commonTemplateResolver(resolver, classpathResolver);
         classpathResolver.setCheckExistence(true);
         classpathResolver.setPrefix(resolver.getPrefix() + resolver.getTemplateFolder());

--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafClassLoaderTemplateResolver.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafClassLoaderTemplateResolver.java
@@ -1,0 +1,29 @@
+package org.broadleafcommerce.presentation.thymeleaf3.resolver;
+
+import org.thymeleaf.IEngineConfiguration;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.templateresource.ITemplateResource;
+
+import java.util.Map;
+
+public class BroadleafClassLoaderTemplateResolver extends ClassLoaderTemplateResolver {
+
+    private final ClassLoader classLoader;
+
+    public BroadleafClassLoaderTemplateResolver() {
+        this(null);
+    }
+
+    public BroadleafClassLoaderTemplateResolver(final ClassLoader classLoader) {
+        super();
+        // Class Loader might be null if we want to apply the default one
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    protected ITemplateResource computeTemplateResource(
+            final IEngineConfiguration configuration, final String ownerTemplate, final String template, final String resourceName, final String characterEncoding, final Map<String, Object> templateResolutionAttributes) {
+        return new BroadleafClassLoaderTemplateResource(this.classLoader, resourceName, characterEncoding);
+    }
+
+}

--- a/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafClassLoaderTemplateResource.java
+++ b/broadleaf-thymeleaf3-presentation/src/main/java/org/broadleafcommerce/presentation/thymeleaf3/resolver/BroadleafClassLoaderTemplateResource.java
@@ -1,0 +1,61 @@
+package org.broadleafcommerce.presentation.thymeleaf3.resolver;
+
+import org.broadleafcommerce.common.util.EfficientLRUMap;
+import org.thymeleaf.templateresource.ClassLoaderTemplateResource;
+import org.thymeleaf.templateresource.ITemplateResource;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Map;
+
+public class BroadleafClassLoaderTemplateResource implements ITemplateResource {
+
+    private final ClassLoaderTemplateResource delegateTemplateResource;
+
+    protected static final Map<String, Boolean> RESOURCE_PATH_CACHE = new EfficientLRUMap<>(10000);
+
+    public BroadleafClassLoaderTemplateResource(final ClassLoader classLoader, final String path, final String characterEncoding) {
+        delegateTemplateResource = new ClassLoaderTemplateResource(classLoader, path, characterEncoding);
+    }
+
+    @Override
+    public String getDescription() {
+        return delegateTemplateResource.getDescription();
+    }
+
+    @Override
+    public String getBaseName() {
+        return delegateTemplateResource.getBaseName();
+    }
+
+    @Override
+    public boolean exists() {
+        Boolean fromCache = getFromCache(getDescription());
+        if (fromCache != null) {
+            return fromCache;
+        }
+        boolean resourcePresent = delegateTemplateResource.exists();
+        addToCache(getDescription(), resourcePresent);
+
+        return resourcePresent;
+    }
+
+    public Boolean getFromCache(String cacheKey) {
+        return RESOURCE_PATH_CACHE.get(cacheKey);
+    }
+
+    public void addToCache(String cacheKey, Boolean isExist) {
+        RESOURCE_PATH_CACHE.put(cacheKey, isExist);
+    }
+
+    @Override
+    public Reader reader() throws IOException {
+        return delegateTemplateResource.reader();
+    }
+
+    @Override
+    public ITemplateResource relative(String relativeLocation) {
+        return delegateTemplateResource.relative(relativeLocation);
+    }
+
+}


### PR DESCRIPTION
**A Brief Overview**
The operation "is template exists for path" when resolving templates is the most time-consuming.
Usually, we have dozens of possible paths for the template and to find a proper one - we need to iterate that path list and resolve each one to check if the resource exists or not.
In the current solution, we cache in a map a path value for the template (a key) and isExist check result - a value (true/false).

There are **cache.template.exists.for.path** property to control this caching.

By default:

_common-shared.properties:_
cache.template.exists.for.path=true

_default-shared.properties:_
cache.template.exists.for.path=false

**Link to QA issue**
[Link](https://github.com/BroadleafCommerce/QA/issues/5066)